### PR TITLE
fix: handle multi word callout IDs

### DIFF
--- a/src/utils/calloutTitleUtils.ts
+++ b/src/utils/calloutTitleUtils.ts
@@ -1,8 +1,8 @@
 import { getTrimmedFirstCapturingGroupIfExists } from "./regexUtils";
 import { toTitleCaseWord } from "./stringUtils";
 
-const CALLOUT_ID_REGEX = /^> \[!(\w+)\]/;
-const CALLOUT_TITLE_REGEX = /^> \[!\w+\] (.+)/;
+export const CALLOUT_HEADER_WITH_ID_CAPTURE_REGEX = /^> \[!(.+)\]/;
+const CALLOUT_TITLE_REGEX = /^> \[!.+\] (.+)/;
 const HEADING_TITLE_REGEX = /^#+ (.+)/;
 
 export function makeCalloutHeader({
@@ -21,7 +21,7 @@ function makeBaseCalloutHeader(calloutID: string): string {
 }
 
 export function getDefaultCalloutTitle(calloutID: string): string {
-  return toTitleCaseWord(calloutID);
+  return toTitleCaseWord(calloutID).replace(/-/g, " ");
 }
 
 export function makeDefaultCalloutHeader(calloutID: string): string {
@@ -56,7 +56,10 @@ function getCalloutID(fullCalloutText: string): string {
 }
 
 function getTrimmedCalloutIDIfExists(fullCalloutText: string): string | undefined {
-  return getTrimmedFirstCapturingGroupIfExists(CALLOUT_ID_REGEX, fullCalloutText);
+  return getTrimmedFirstCapturingGroupIfExists(
+    CALLOUT_HEADER_WITH_ID_CAPTURE_REGEX,
+    fullCalloutText
+  );
 }
 
 /**

--- a/src/utils/editorCheckCallbackUtils.ts
+++ b/src/utils/editorCheckCallbackUtils.ts
@@ -1,7 +1,6 @@
 import { Command, Editor } from "obsidian";
+import { CALLOUT_HEADER_WITH_ID_CAPTURE_REGEX } from "./calloutTitleUtils";
 import { getSelectedLinesRangeAndText } from "./selectionUtils";
-
-const CALLOUT_HEADER_REGEX = /^> \[!\w+\]/;
 
 /**
  * See Obsidian docs for `editorCheckCallback` for more information:
@@ -31,10 +30,14 @@ export function makeCalloutSelectionCheckCallback(
 ): EditorCheckCallback {
   return (checking, editor, _ctx) => {
     if (!editor.somethingSelected()) return false; // Only show the command if text is selected
-    const { selectedLinesText } = getSelectedLinesRangeAndText(editor);
-    if (!CALLOUT_HEADER_REGEX.test(selectedLinesText)) return false; // Only show the command if the selected text is a callout
+    if (!isFirstSelectedLineCalloutHeader(editor)) return false; // Only show the command if the selected lines begin with a callout
     return showOrRunCommand(editorAction, editor, checking);
   };
+}
+
+function isFirstSelectedLineCalloutHeader(editor: Editor): boolean {
+  const { selectedLinesText } = getSelectedLinesRangeAndText(editor);
+  return CALLOUT_HEADER_WITH_ID_CAPTURE_REGEX.test(selectedLinesText);
 }
 
 /**
@@ -50,6 +53,10 @@ export function makeCurrentLineCheckCallback(
   };
 }
 
+/**
+ * Shows or runs the given editor action depending on whether `checking` is true. Helper function
+ * for creating editor check callbacks.
+ */
 function showOrRunCommand(
   editorAction: (editor: Editor) => void,
   editor: Editor,


### PR DESCRIPTION
Callout IDs can be anything until the ] (not just word characters), and their default titles should have hyphens replaced by spaces.

Fixes #1 